### PR TITLE
Create TL-Hediffs_food.xml

### DIFF
--- a/Languages/English/DefInjected/HediffDef/TL-Hediffs_food.xml
+++ b/Languages/English/DefInjected/HediffDef/TL-Hediffs_food.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <HedMochi.label>Speedy Mochi</HedMochi.label>
+  <HedMochi.stages.0.label>I ate some Mochi.</HedMochi.stages.0.label>
+
+  <HedMochi2.label>Joyous Mochi</HedMochi2.label>
+  <HedMochi2.stages.0.label>I ate some Mochi.</HedMochi2.stages.0.label>
+
+  <HedPuffedRice.label>Explosive power dwells in my body!!</HedPuffedRice.label>
+  <HedPuffedRice.stages.0.label>I ate some Muri.</HedPuffedRice.stages.0.label>
+
+  <HedFermentedFood.label>Fermented food with a smell</HedFermentedFood.label>
+  <HedFermentedFood.stages.0.label>I ate fermented food.</HedFermentedFood.stages.0.label>
+
+  <HedFishFood.label>Fish power!!</HedFishFood.label>
+  <HedFishFood.stages.0.label>Fish is good, fish is good!<./HedFishFood.stages.0.label>
+
+  <HedFreshFishFood.label>Seafood Heaven!!</HedFreshFishFood.label>
+  <HedFreshFishFood.stages.0.label>Seafood best food.</HedFreshFishFood.stages.0.label>
+
+  <HedNabeFood.label>I'm stuffed!!</HedNabeFood.label>
+  <HedNabeFood.stages.0.label>I can't eat anymore. Really, I can't.</HedNabeFood.stages.0.label>
+
+
+</LanguageData>


### PR DESCRIPTION
Changed Mochi labels to more accurately fit RimWorld's aesthetic.
Added "Some" to several descriptions. This clarifies that the colonist ate food and not something else.
Polished descriptions to reflect the energy and personality of their labels.