### PR TITLE
Create TL-Recipes_Food_MealFine.xml

### DIFF
--- a/Languages/English/DefInjected/RecipeDef/TL-Recipes_Food_MealFine.xml
+++ b/Languages/English/DefInjected/RecipeDef/TL-Recipes_Food_MealFine.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- 手の込んだ食事　卵かけご飯 -->
+
+  <CookBRTKG1.label>Make Brown Rice Tamago kake Gohan</CookBRTKG1.label>
+  <CookBRTKG1.description>Brown rice topped with an egg. A popular breakfast dish in Japan.</CookBRTKG1.description>
+  <CookBRTKG1.jobString>Making BR TKG.</CookBRTKG1.jobString>
+
+  <CookBRTKG4.label>Make Brown Rice Tamago kake Gohan (4)</CookBRTKG4.label>
+  <CookBRTKG4.description>Brown rice topped with an egg. A popular breakfast dish in Japan.</CookBRTKG4.description>
+  <CookBRTKG4.jobString>Making BR TKG.</CookBRTKG4.jobString>
+
+  <CookWRTKG1.label>Make White Rice Tamago kake Gohan</CookWRTKG1.label>
+  <CookWRTKG1.description>White rice topped with an egg. A popular breakfast dish in Japan.</CookWRTKG1.description>
+  <CookWRTKG1.jobString>Making WR TKG.</CookWRTKG1.jobString>
+
+  <CookWRTKG4.label>Make White Rice Tamago kake Gohan (4)</CookWRTKG4.label>
+  <CookWRTKG4.description>White rice topped with an egg. A popular breakfast dish in Japan.</CookWRTKG4.description>
+  <CookWRTKG4.jobString>Making WR TKG.</CookWRTKG4.jobString>
+
+
+  <!-- 手の込んだ食事　肉丼 -->
+
+  <CookBRGyudon1.label>Cook Brown Rice Gyudon</CookBRGyudon1.label>
+  <CookBRGyudon1.description>Traditionally beef over rice; however, whilst on the Rim, any seasoned meat will do.</CookBRGyudon1.description>
+  <CookBRGyudon1.jobString>Cooking BR Gyudon.</CookBRGyudon1.jobString>
+
+  <CookBRGyudon4.label>Cook Brown Rice Gyudon (4)</CookBRGyudon4.label>
+  <CookBRGyudon4.description>Traditionally beef over rice; however, whilst on the Rim, any seasoned meat will do.</CookBRGyudon4.description>
+  <CookBRGyudon4.jobString>Cooking BR Gyudon.</CookBRGyudon4.jobString>
+
+  <CookWRGyudon1.label>Cook White Rice Gyudon</CookWRGyudon1.label>
+  <CookWRGyudon1.description>Traditionally beef over rice; however, whilst on the Rim, any seasoned meat will do.</CookWRGyudon1.description>
+  <CookWRGyudon1.jobString>Cooking WR Gyudon.</CookWRGyudon1.jobString>
+
+  <CookWRGyudon4.label>Cook White Rice Gyudon (4)</CookWRGyudon4.label>
+  <CookWRGyudon4.description>Traditionally beef over rice; however, whilst on the Rim, any seasoned meat will do.</CookWRGyudon4.description>
+  <CookWRGyudon4.jobString>Cooking WR Gyudon.</CookWRGyudon4.jobString>
+
+  <CookSasimi8.label>Make Sashimi (4)</CookSasimi8.label>
+  <CookSasimi8.description>Cut and season raw fish in an appetizing manner.</CookSasimi8.description>
+  <CookSasimi8.jobString>Making Sashimi.</CookSasimi8.jobString>
+
+  <CookSaltGrilledFish8.label>Salt-grilled fish (4)</CookSaltGrilledFish8.label>
+  <CookSaltGrilledFish8.description>Grill fresh fish and season with salt.</CookSaltGrilledFish8.description>
+  <CookSaltGrilledFish8.jobString>Making Salt-grilled fish.</CookSaltGrilledFish8.jobString>
+
+  <CookSteamedFish8.label>Make Boiled fish (4)</CookSteamedFish8.label>
+  <CookSteamedFish8.description>Fish boiled with seasoning.</CookSteamedFish8.description>
+  <CookSteamedFish8.jobString>Making Boiled fish.</CookSteamedFish8.jobString>
+
+  <CookGRTakikomi4.label>Cook Takikomi Gohan (4)</CookGRTakikomi4.label>
+  <CookGRTakikomi4.description>Glutinous rice mixed with cooked meat and vegetables.</CookGRTakikomi4.description>
+  <CookGRTakikomi4.jobString>Cooking Takikomi Gohan.</CookGRTakikomi4.jobString>
+
+  <CookTendon4.label>Cook Tendon (4)</CookTendon4.label>
+  <CookTendon4.description>Prepare several bowls of rice and top each with tempura.</CookTendon4.description>
+  <CookTendon4.jobString>Cooking Tendon.</CookTendon4.jobString>
+
+  <CookOkonomiyaki4.label>Cook Okonomiyaki (4)</CookOkonomiyaki4.label>
+  <CookOkonomiyaki4.description>Grilled pancakes that are topped or stuffed with wide array of ingredients.</CookOkonomiyaki4.description>
+  <CookOkonomiyaki4.jobString>Cooking Okonomiyaki.</CookOkonomiyaki4.jobString>
+
+  <CookUdon4.label>Cook Udon (4)</CookUdon4.label>
+  <CookUdon4.description>Make several bowls of noodles.</CookUdon4.description>
+  <CookUdon4.jobString>Cooking Udon.</CookUdon4.jobString>
+
+  <CookOden8.label>Cook Oden (8)</CookOden8.label>
+  <CookOden8.description>Prepare eight servings of Oden.</CookOden8.description>
+  <CookOden8.jobString>Cooking Oden.</CookOden8.jobString>
+
+
+</LanguageData>


### PR DESCRIPTION
Expanded abbreviations such as "BR, WR, and TKG," to fit Rimworld's base game aesthetic. TKG was specifically changed to allow players to learn the formal name of the dish. According to research TKG is a common acronym for the dish in Japan. I will add this cultural note to the item's proper description. I understand the desire to avoid visual clutter, but using the full words avoids any ambiguity that might confuse some players. Moreover, I kept the abbreviations in every jobstring, thus allowing the player to become familiar with those terms that way.
Added spacing between item names and quantities.
Added periods to jobstrings.
Researched and expanded the description of Sashimi appropriately.
Translated and localized the descriptions for Takikomi Gohan, Tendon, Okonomiyaki, Udon, and Oden.