### PR TITLE
Create TL-Recipes_Product.xml

### DIFF
--- a/Languages/English/DefInjected/RecipeDef/TL-Recipes_Product.xml
+++ b/Languages/English/DefInjected/RecipeDef/TL-Recipes_Product.xml
@@ -1,0 +1,97 @@
+
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- 肥料作成 -->
+
+  <MakeTatamiStraw18.label>Make Building straw (18)</MakeTatamiStraw18.label>
+  <MakeTatamiStraw18.description>Make straw for building.</MakeTatamiStraw18.description>
+  <MakeTatamiStraw18.jobString>Making Building straw.</MakeTatamiStraw18.jobString>
+
+  <MakeTatamiStraw30.label>Make Building straw (30)</MakeTatamiStraw30.label>
+  <MakeTatamiStraw30.description>Make straw for building.</MakeTatamiStraw30.description>
+  <MakeTatamiStraw30.jobString>Making Building straw.</MakeTatamiStraw30.jobString>
+
+  <MakeTatamiStraw60.label>Make Building straw (60)</MakeTatamiStraw60.label>
+  <MakeTatamiStraw60.description>Make straw for building.</MakeTatamiStraw60.description>
+  <MakeTatamiStraw60.jobString>Making Building straw.</MakeTatamiStraw60.jobString>
+
+  <MakeTatamiG.label>Tatami (1 quire)</MakeTatamiG.label>
+  <MakeTatamiG.description>Make a Tatami from Building straw.</MakeTatamiG.description>
+  <MakeTatamiG.jobString>Making Tatami.</MakeTatamiG.jobString>
+
+  <MakeR_Compost10.label>Make Compost (10)</MakeR_Compost10.label>
+  <MakeR_Compost10.description>Make fertilizer from straw and rice bran.</MakeR_Compost10.description>
+  <MakeR_Compost10.jobString>Making Compost.</MakeR_Compost10.jobString>
+
+  <MakeR_Compost50.label>Make Compost (50)</MakeR_Compost50.label>
+  <MakeR_Compost50.description>Make fertilizer from straw and rice bran.</MakeR_Compost50.description>
+  <MakeR_Compost50.jobString>Making Compost.</MakeR_Compost50.jobString>
+
+  <MakeR_Compost100.label>Make Compost (100)</MakeR_Compost100.label>
+  <MakeR_Compost100.description>Make fertilizer from straw and rice bran.</MakeR_Compost100.description>
+  <MakeR_Compost100.jobString>Making Compost</MakeR_Compost100.jobString>
+
+
+  <!-- 燃料作成 -->
+
+  <MakeMomigalite10.label>Make Momigalite (10)</MakeMomigalite10.label>
+  <MakeMomigalite10.description>Process Outer hull into fuel.</MakeMomigalite10.description>
+  <MakeMomigalite10.jobString>Making Momigalite.</MakeMomigalite10.jobString>
+
+  <MakeMomigalite50.label>Make Momigalite (50)</MakeMomigalite50.label>
+  <MakeMomigalite50.description>Process Outer hull into fuel.</MakeMomigalite50.description>
+  <MakeMomigalite50.jobString>Making Momigalite.</MakeMomigalite50.jobString>
+
+  <MakeMomigalite100.label>Make Momigalite (100)</MakeMomigalite100.label>
+  <MakeMomigalite100.description>Process Outer hull into fuel.</MakeMomigalite100.description>
+  <MakeMomigalite100.jobString>Making Momigalite.</MakeMomigalite100.jobString>
+
+  <MakeFuelStraw10.label>Make Fuel straw (10)</MakeFuelStraw10.label>
+  <MakeFuelStraw10.description>Process straw into fuel.</MakeFuelStraw10.description>
+  <MakeFuelStraw10.jobString>Making Fuel straw.</MakeFuelStraw10.jobString>
+
+  <MakeFuelStraw50.label>Make Fuel straw (50)</MakeFuelStraw50.label>
+  <MakeFuelStraw50.description>Process straw into fuel.</MakeFuelStraw50.description>
+  <MakeFuelStraw50.jobString>Making Fuel straw.</MakeFuelStraw50.jobString>
+
+  <MakeFuelStraw100.label>Make Fuel straw (100)</MakeFuelStraw100.label>
+  <MakeFuelStraw100.description>Process straw into fuel.</MakeFuelStraw100.description>
+  <MakeFuelStraw100.jobString>Making Fuel straw.</MakeFuelStraw100.jobString>
+
+
+  <!-- 泥収集 -->
+
+  <ZP_CollectMud.label>Gather mud</ZP_CollectMud.label>
+  <ZP_CollectMud.description>Gather mud for soil improvement.</ZP_CollectMud.description>
+  <ZP_CollectMud.jobString>Gathering mud.</ZP_CollectMud.jobString>
+
+
+  <!-- 副産物袋 -->
+
+  <MakeRiceByproduct.label>Make a by-product bag (100)</MakeRiceByproduct.label>
+  <MakeRiceByproduct.description>Make a by-product bag.</MakeRiceByproduct.description>
+  <MakeRiceByproduct.jobString>Making a by-product bag.</MakeRiceByproduct.jobString>
+
+  <TakeRiceByproduct_RC.label>Take rice bran and Outer hull from a by-product bag</TakeRiceByproduct_RC.label>
+  <TakeRiceByproduct_RC.description>Take rice bran and Outer hull from a by-product bag.</TakeRiceByproduct_RC.description>
+  <TakeRiceByproduct_RC.jobString>Taking rice bran and Outer hull from a by-product bag.</TakeRiceByproduct_RC.jobString>
+
+  <TakeRiceByproduct_R.label>Take rice bran from a by-product bag</TakeRiceByproduct_R.label>
+  <TakeRiceByproduct_R.description>Take rice bran from a by-product bag\n CAUTION: Outer hull will be erased.</TakeRiceByproduct_R.description>
+  <TakeRiceByproduct_R.jobString>Taking rice bran from a by-product bag.</TakeRiceByproduct_R.jobString>
+
+  <TakeRiceByproduct_C.label>Take Outer hull from a by-product bag</TakeRiceByproduct_C.label>
+  <TakeRiceByproduct_C.description>Take Outer hull from a by-product bag\nCAUTION: Rice bran will be erased.</TakeRiceByproduct_C.description>
+  <TakeRiceByproduct_C.jobString>Taking Outer hull from a by-product bag.</TakeRiceByproduct_C.jobString>
+
+  <MakeChemfuelFromRice.label>Make chemfuel from rice by-product bag and straw.</MakeChemfuelFromRice.label>
+  <MakeChemfuelFromRice.description>Make a batch of chemfuel by gasifying rice byproduct and straw.</MakeChemfuelFromRice.description>
+  <MakeChemfuelFromRice.jobString>Refining chemfuel from rice by-product and straw..</MakeChemfuelFromRice.jobString>
+
+  <MakeRBCeramic.label>Make Rice Bran Ceramics (10)</MakeRBCeramic.label>
+  <MakeRBCeramic.description>After crushing and compressing the by-product bag, heat is applied and it is molded.</MakeRBCeramic.description>
+  <MakeRBCeramic.jobString>Making Rice Bran Ceramics.</MakeRBCeramic.jobString>
+
+
+</LanguageData>


### PR DESCRIPTION
Added spacing between item names and quantities.
Adjusted capitalization at the start of sentences.
Corrected multiple misspellings of "Outer" as "Outher."
Expanded acronym "RB" to fit Rimworld's grammar style.